### PR TITLE
add safe area for continue button

### DIFF
--- a/Powerup/Base.lproj/Main.storyboard
+++ b/Powerup/Base.lproj/Main.storyboard
@@ -422,7 +422,7 @@
                             <constraint firstItem="e5J-1l-00w" firstAttribute="bottom" secondItem="6Xa-mf-lH7" secondAttribute="bottom" constant="62" id="ZEZ-6n-REy"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="top" secondItem="FxG-LX-wOY" secondAttribute="top" id="bSa-GP-dEA"/>
                             <constraint firstItem="we5-9v-c2u" firstAttribute="centerX" secondItem="acu-mp-gO5" secondAttribute="centerX" id="cgq-jE-LEd"/>
-                            <constraint firstItem="acu-mp-gO5" firstAttribute="leading" secondItem="e5J-1l-00w" secondAttribute="leading" id="d03-qA-Ezk"/>
+                            <constraint firstItem="acu-mp-gO5" firstAttribute="leading" secondItem="8Iq-DJ-45h" secondAttribute="leading" id="d03-qA-Ezk"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="leading" secondItem="8Q4-PA-meK" secondAttribute="leading" id="dtt-io-xuQ"/>
                             <constraint firstItem="we5-9v-c2u" firstAttribute="top" secondItem="1rN-B1-EyF" secondAttribute="bottom" constant="74" id="elg-Uv-pRL"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="top" secondItem="we5-9v-c2u" secondAttribute="bottom" constant="15" id="fyM-Mw-O3g"/>

--- a/Powerup/Base.lproj/Main.storyboard
+++ b/Powerup/Base.lproj/Main.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="eFm-LF-3yb">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eFm-LF-3yb">
     <device id="retina5_5" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -16,10 +17,6 @@
         <scene sceneID="phh-au-jgs">
             <objects>
                 <viewController id="1wo-38-EOZ" customClass="AboutViewController" customModule="Powerup" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="w4t-RZ-2Jc"/>
-                        <viewControllerLayoutGuide type="bottom" id="Dsc-5c-dQF"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="9yw-ae-sTQ">
                         <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -70,18 +67,19 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="tEY-r5-Byb" firstAttribute="width" secondItem="9yw-ae-sTQ" secondAttribute="width" id="56D-os-mnU"/>
-                            <constraint firstItem="Dsc-5c-dQF" firstAttribute="top" secondItem="FdT-xN-nZO" secondAttribute="bottom" constant="15" id="A2q-7P-MlC"/>
+                            <constraint firstItem="2TS-AX-Kbm" firstAttribute="bottom" secondItem="FdT-xN-nZO" secondAttribute="bottom" constant="15" id="A2q-7P-MlC"/>
                             <constraint firstItem="ycz-xD-2DD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="CMB-we-gPZ" secondAttribute="trailing" constant="400" id="EaY-Ix-SWB"/>
                             <constraint firstItem="FdT-xN-nZO" firstAttribute="top" secondItem="CMB-we-gPZ" secondAttribute="bottom" constant="6.6699999999999999" id="FkG-kY-1ik"/>
-                            <constraint firstItem="tEY-r5-Byb" firstAttribute="centerX" secondItem="9yw-ae-sTQ" secondAttribute="centerX" id="Jlp-A4-hFo"/>
-                            <constraint firstAttribute="trailing" secondItem="ycz-xD-2DD" secondAttribute="trailing" constant="30" id="RIi-uV-CQv"/>
-                            <constraint firstItem="CMB-we-gPZ" firstAttribute="top" secondItem="w4t-RZ-2Jc" secondAttribute="bottom" constant="15" id="Yug-Ps-SBh"/>
+                            <constraint firstItem="tEY-r5-Byb" firstAttribute="centerX" secondItem="2TS-AX-Kbm" secondAttribute="centerX" id="Jlp-A4-hFo"/>
+                            <constraint firstItem="2TS-AX-Kbm" firstAttribute="trailing" secondItem="ycz-xD-2DD" secondAttribute="trailing" constant="30" id="RIi-uV-CQv"/>
+                            <constraint firstItem="CMB-we-gPZ" firstAttribute="top" secondItem="2TS-AX-Kbm" secondAttribute="top" constant="15" id="Yug-Ps-SBh"/>
                             <constraint firstItem="tEY-r5-Byb" firstAttribute="centerY" secondItem="9yw-ae-sTQ" secondAttribute="centerY" id="dWg-zs-4Ea"/>
                             <constraint firstItem="FdT-xN-nZO" firstAttribute="leading" secondItem="9yw-ae-sTQ" secondAttribute="leadingMargin" constant="15" id="hEk-Zq-RbH"/>
                             <constraint firstItem="ycz-xD-2DD" firstAttribute="top" secondItem="9yw-ae-sTQ" secondAttribute="top" constant="30" id="ne6-G4-Q5R"/>
                             <constraint firstItem="tEY-r5-Byb" firstAttribute="height" secondItem="9yw-ae-sTQ" secondAttribute="height" id="uAq-Tf-1Dp"/>
                             <constraint firstItem="CMB-we-gPZ" firstAttribute="leading" secondItem="9yw-ae-sTQ" secondAttribute="leadingMargin" constant="15" id="ute-Fm-ALn"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="2TS-AX-Kbm"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Zwe-o9-mfo" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -92,10 +90,6 @@
         <scene sceneID="bOj-Fm-Fh1">
             <objects>
                 <viewController storyboardIdentifier="1" id="S65-lq-9jr" customClass="StartViewController" customModule="Powerup" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="UuV-o1-Bd9"/>
-                        <viewControllerLayoutGuide type="bottom" id="crB-5J-nEd"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Gv1-Un-5xq">
                         <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -132,8 +126,8 @@
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="lq3-AT-Fhu" firstAttribute="top" secondItem="UuV-o1-Bd9" secondAttribute="bottom" id="FaX-V4-6yU"/>
-                            <constraint firstItem="nQo-QP-3Ls" firstAttribute="centerX" secondItem="Gv1-Un-5xq" secondAttribute="centerX" multiplier="0.25" id="K3h-Ns-oQI"/>
+                            <constraint firstItem="lq3-AT-Fhu" firstAttribute="top" secondItem="wgB-vJ-s1i" secondAttribute="top" id="FaX-V4-6yU"/>
+                            <constraint firstItem="nQo-QP-3Ls" firstAttribute="centerX" secondItem="wgB-vJ-s1i" secondAttribute="centerX" multiplier="0.25" id="K3h-Ns-oQI"/>
                             <constraint firstItem="nQo-QP-3Ls" firstAttribute="centerY" secondItem="Gv1-Un-5xq" secondAttribute="centerY" multiplier="0.15" id="KMg-Nn-1pm"/>
                             <constraint firstItem="nQo-QP-3Ls" firstAttribute="width" secondItem="Gv1-Un-5xq" secondAttribute="width" multiplier="0.2" id="Lnn-Er-cvZ"/>
                             <constraint firstItem="0jE-f7-7E2" firstAttribute="height" secondItem="lq3-AT-Fhu" secondAttribute="height" multiplier="0.1" id="Ofe-5w-cu3"/>
@@ -141,14 +135,15 @@
                             <constraint firstItem="nQo-QP-3Ls" firstAttribute="height" secondItem="Gv1-Un-5xq" secondAttribute="height" multiplier="0.1" id="alm-w9-qvX"/>
                             <constraint firstItem="0jE-f7-7E2" firstAttribute="centerY" secondItem="lq3-AT-Fhu" secondAttribute="centerY" multiplier="1.47" id="fgc-Kd-NW5"/>
                             <constraint firstItem="0jE-f7-7E2" firstAttribute="width" secondItem="lq3-AT-Fhu" secondAttribute="width" multiplier="0.3" id="mfj-P1-zfD"/>
-                            <constraint firstItem="crB-5J-nEd" firstAttribute="top" secondItem="lq3-AT-Fhu" secondAttribute="bottom" id="phr-m3-EDy"/>
-                            <constraint firstItem="lq3-AT-Fhu" firstAttribute="leading" secondItem="Gv1-Un-5xq" secondAttribute="leading" id="teQ-PX-rqE"/>
+                            <constraint firstItem="wgB-vJ-s1i" firstAttribute="bottom" secondItem="lq3-AT-Fhu" secondAttribute="bottom" id="phr-m3-EDy"/>
+                            <constraint firstItem="lq3-AT-Fhu" firstAttribute="leading" secondItem="wgB-vJ-s1i" secondAttribute="leading" id="teQ-PX-rqE"/>
                             <constraint firstItem="S80-hG-Bup" firstAttribute="width" secondItem="lq3-AT-Fhu" secondAttribute="width" multiplier="0.3" id="uow-g9-hs0"/>
                             <constraint firstItem="0jE-f7-7E2" firstAttribute="centerX" secondItem="lq3-AT-Fhu" secondAttribute="centerX" id="veA-hN-uh1"/>
-                            <constraint firstAttribute="trailing" secondItem="lq3-AT-Fhu" secondAttribute="trailing" id="yFN-b4-Mer"/>
+                            <constraint firstItem="wgB-vJ-s1i" firstAttribute="trailing" secondItem="lq3-AT-Fhu" secondAttribute="trailing" id="yFN-b4-Mer"/>
                             <constraint firstItem="S80-hG-Bup" firstAttribute="centerY" secondItem="lq3-AT-Fhu" secondAttribute="centerY" multiplier="1.71" id="yXG-ga-TAE"/>
                             <constraint firstItem="S80-hG-Bup" firstAttribute="height" secondItem="lq3-AT-Fhu" secondAttribute="height" multiplier="0.1" id="z8V-Uc-K0I"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="wgB-vJ-s1i"/>
                     </view>
                     <navigationItem key="navigationItem" id="EmJ-7a-eTn"/>
                     <connections>
@@ -165,10 +160,6 @@
         <scene sceneID="zcc-y7-lCe">
             <objects>
                 <viewController storyboardIdentifier="Customize Avatar View Controller" id="vCf-Jb-qhY" customClass="CustomizeAvatarViewController" customModule="Powerup" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="nLu-Qc-m2d"/>
-                        <viewControllerLayoutGuide type="bottom" id="lW9-er-4kz"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8Iq-DJ-45h">
                         <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -177,16 +168,16 @@
                                 <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                             </imageView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="avatar_skin_01" translatesAutoresizingMaskIntoConstraints="NO" id="6Xa-mf-lH7" userLabel="Face Image">
-                                <rect key="frame" x="279" y="179" width="91" height="173"/>
+                                <rect key="frame" x="279" y="179" width="91.000000000000114" height="173"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="91" id="V82-Sm-pnh"/>
                                 </constraints>
                             </imageView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="avatar_eyes_01" translatesAutoresizingMaskIntoConstraints="NO" id="FxG-LX-wOY" userLabel="Eyes Image">
-                                <rect key="frame" x="279" y="179" width="91" height="173"/>
+                                <rect key="frame" x="279" y="179" width="91.000000000000114" height="173"/>
                             </imageView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="avatar_hair_01" translatesAutoresizingMaskIntoConstraints="NO" id="8IZ-CD-HcB" userLabel="Hair Image">
-                                <rect key="frame" x="279" y="179" width="91" height="173"/>
+                                <rect key="frame" x="279" y="179" width="91.000000000000114" height="173"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9nJ-HE-yPQ" userLabel="Continue Button">
                                 <rect key="frame" x="597" y="299" width="139" height="50"/>
@@ -208,7 +199,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="156.33333333333334" height="50"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Skin" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ags-IQ-Dxd">
-                                                <rect key="frame" x="60.333333333333329" y="14.666666666666657" width="35.333333333333329" height="21"/>
+                                                <rect key="frame" x="57.666666666666671" y="14" width="41" height="22"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="18"/>
                                                 <color key="textColor" red="0.38069673900000001" green="0.59913557640000004" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -281,7 +272,7 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Eyes" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zbt-qX-ypc">
-                                                <rect key="frame" x="58.666666666666657" y="14.666666666666657" width="38.666666666666657" height="21"/>
+                                                <rect key="frame" x="56.666666666666657" y="14" width="42.666666666666657" height="22"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="18"/>
                                                 <color key="textColor" red="0.38069673900000001" green="0.59913557640000004" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -328,7 +319,7 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Clothes" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5p4-KD-Db0">
-                                                <rect key="frame" x="50.333333333333314" y="15.666666666666659" width="55" height="18.666666666666671"/>
+                                                <rect key="frame" x="46.666666666666629" y="15.333333333333345" width="62.333333333333343" height="19.666666666666671"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="16"/>
                                                 <color key="textColor" red="0.38069673900000001" green="0.59913557640000004" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -375,7 +366,7 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hair" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4kg-9a-CDD">
-                                                <rect key="frame" x="62" y="14.666666666666657" width="32.666666666666657" height="21"/>
+                                                <rect key="frame" x="59" y="14" width="38.333333333333343" height="22"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="18"/>
                                                 <color key="textColor" red="0.38069673900000001" green="0.59913557640000004" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -395,10 +386,10 @@
                                 </subviews>
                             </stackView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="avatar_clothes_01" translatesAutoresizingMaskIntoConstraints="NO" id="8Q4-PA-meK" userLabel="Clothes Image">
-                                <rect key="frame" x="279" y="179" width="91" height="173"/>
+                                <rect key="frame" x="279" y="179" width="91.000000000000114" height="173"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1rN-B1-EyF" userLabel="back button">
-                                <rect key="frame" x="20" y="15" width="51" height="25"/>
+                                <rect key="frame" x="20" y="15" width="25.666666666666671" height="25"/>
                                 <state key="normal" image="left_arrow"/>
                                 <connections>
                                     <action selector="backButtonTouched:" destination="vCf-Jb-qhY" eventType="touchUpInside" id="gtS-ZK-i5D"/>
@@ -415,29 +406,29 @@
                         <constraints>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="top" secondItem="KeK-fp-IKT" secondAttribute="bottom" constant="19" id="0qs-43-dKB"/>
                             <constraint firstItem="KeK-fp-IKT" firstAttribute="centerY" secondItem="we5-9v-c2u" secondAttribute="centerY" id="4df-yB-Eld"/>
-                            <constraint firstItem="6Xa-mf-lH7" firstAttribute="leading" secondItem="8Iq-DJ-45h" secondAttribute="leading" constant="279" id="55P-VJ-wru"/>
+                            <constraint firstItem="6Xa-mf-lH7" firstAttribute="leading" secondItem="e5J-1l-00w" secondAttribute="leading" constant="279" id="55P-VJ-wru"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="bottom" secondItem="8Q4-PA-meK" secondAttribute="bottom" id="75V-69-1tf"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="top" secondItem="8Q4-PA-meK" secondAttribute="top" id="8dA-x3-lag"/>
-                            <constraint firstItem="1rN-B1-EyF" firstAttribute="top" secondItem="nLu-Qc-m2d" secondAttribute="bottom" constant="15" id="9Hn-mE-dkU"/>
+                            <constraint firstItem="1rN-B1-EyF" firstAttribute="top" secondItem="e5J-1l-00w" secondAttribute="top" constant="15" id="9Hn-mE-dkU"/>
                             <constraint firstItem="1rN-B1-EyF" firstAttribute="leading" secondItem="8Iq-DJ-45h" secondAttribute="leadingMargin" id="BWz-B8-ezX"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="top" secondItem="8IZ-CD-HcB" secondAttribute="top" id="Dh9-99-ek4"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="trailing" secondItem="8Q4-PA-meK" secondAttribute="trailing" id="FKN-RU-8UU"/>
-                            <constraint firstItem="acu-mp-gO5" firstAttribute="top" secondItem="nLu-Qc-m2d" secondAttribute="bottom" id="HZM-zs-otC"/>
+                            <constraint firstItem="acu-mp-gO5" firstAttribute="top" secondItem="8Iq-DJ-45h" secondAttribute="top" id="HZM-zs-otC"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="bottom" secondItem="FxG-LX-wOY" secondAttribute="bottom" id="KPJ-xm-nQX"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="bottom" secondItem="8IZ-CD-HcB" secondAttribute="bottom" id="LYQ-E4-Cyh"/>
-                            <constraint firstAttribute="trailing" secondItem="acu-mp-gO5" secondAttribute="trailing" id="N3U-yx-Tyq"/>
+                            <constraint firstItem="e5J-1l-00w" firstAttribute="trailing" secondItem="acu-mp-gO5" secondAttribute="trailing" id="N3U-yx-Tyq"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="leading" secondItem="8IZ-CD-HcB" secondAttribute="leading" id="NIA-JN-i6c"/>
                             <constraint firstItem="we5-9v-c2u" firstAttribute="leading" secondItem="8Iq-DJ-45h" secondAttribute="leadingMargin" constant="-2" id="XXm-mh-9hK"/>
-                            <constraint firstItem="lW9-er-4kz" firstAttribute="top" secondItem="6Xa-mf-lH7" secondAttribute="bottom" constant="62" id="ZEZ-6n-REy"/>
+                            <constraint firstItem="e5J-1l-00w" firstAttribute="bottom" secondItem="6Xa-mf-lH7" secondAttribute="bottom" constant="62" id="ZEZ-6n-REy"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="top" secondItem="FxG-LX-wOY" secondAttribute="top" id="bSa-GP-dEA"/>
                             <constraint firstItem="we5-9v-c2u" firstAttribute="centerX" secondItem="acu-mp-gO5" secondAttribute="centerX" id="cgq-jE-LEd"/>
-                            <constraint firstItem="acu-mp-gO5" firstAttribute="leading" secondItem="8Iq-DJ-45h" secondAttribute="leading" id="d03-qA-Ezk"/>
+                            <constraint firstItem="acu-mp-gO5" firstAttribute="leading" secondItem="e5J-1l-00w" secondAttribute="leading" id="d03-qA-Ezk"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="leading" secondItem="8Q4-PA-meK" secondAttribute="leading" id="dtt-io-xuQ"/>
                             <constraint firstItem="we5-9v-c2u" firstAttribute="top" secondItem="1rN-B1-EyF" secondAttribute="bottom" constant="74" id="elg-Uv-pRL"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="top" secondItem="we5-9v-c2u" secondAttribute="bottom" constant="15" id="fyM-Mw-O3g"/>
-                            <constraint firstItem="lW9-er-4kz" firstAttribute="top" secondItem="acu-mp-gO5" secondAttribute="bottom" id="h1r-kc-hCA"/>
-                            <constraint firstItem="lW9-er-4kz" firstAttribute="top" secondItem="9nJ-HE-yPQ" secondAttribute="bottom" constant="65" id="hVp-9Y-L3c"/>
-                            <constraint firstAttribute="trailing" secondItem="9nJ-HE-yPQ" secondAttribute="trailing" id="jf4-x1-jAB"/>
+                            <constraint firstAttribute="bottom" secondItem="acu-mp-gO5" secondAttribute="bottom" id="h1r-kc-hCA"/>
+                            <constraint firstItem="e5J-1l-00w" firstAttribute="bottom" secondItem="9nJ-HE-yPQ" secondAttribute="bottom" constant="65" id="hVp-9Y-L3c"/>
+                            <constraint firstItem="e5J-1l-00w" firstAttribute="trailing" secondItem="9nJ-HE-yPQ" secondAttribute="trailing" id="jf4-x1-jAB"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="trailing" secondItem="FxG-LX-wOY" secondAttribute="trailing" id="jtZ-q2-Tjh"/>
                             <constraint firstItem="KeK-fp-IKT" firstAttribute="trailing" secondItem="9nJ-HE-yPQ" secondAttribute="trailing" id="kXO-QK-McW"/>
                             <constraint firstItem="6Xa-mf-lH7" firstAttribute="trailing" secondItem="8IZ-CD-HcB" secondAttribute="trailing" id="lMA-lU-cWp"/>
@@ -445,6 +436,7 @@
                             <constraint firstAttribute="bottom" secondItem="we5-9v-c2u" secondAttribute="bottom" constant="250" id="oTZ-QV-Xc8"/>
                             <constraint firstItem="KeK-fp-IKT" firstAttribute="leading" secondItem="acu-mp-gO5" secondAttribute="leading" id="yBs-8i-BOz"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="e5J-1l-00w"/>
                     </view>
                     <navigationItem key="navigationItem" id="Wzb-7i-Gda"/>
                     <connections>
@@ -476,10 +468,6 @@
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController storyboardIdentifier="Scenario View Controller" id="BYZ-38-t0r" userLabel="ScenarioViewController" customClass="ScenarioViewController" customModule="Powerup" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
-                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -507,7 +495,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Marcello" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6u7-zE-DVc">
-                                <rect key="frame" x="603" y="379.66666666666669" width="76.333333333333371" height="24.333333333333314"/>
+                                <rect key="frame" x="597.33333333333337" y="379.66666666666669" width="87.666666666666629" height="24.333333333333314"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="20"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -586,7 +574,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scenario" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nut-8U-Q0c" userLabel="Scenario Name Label">
-                                <rect key="frame" x="20" y="20" width="79" height="23.333333333333329"/>
+                                <rect key="frame" x="19.999999999999993" y="20" width="89.333333333333314" height="24.666666666666671"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="20"/>
                                 <color key="textColor" red="0.38069673900000001" green="0.59913557640000004" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -596,33 +584,34 @@
                             <constraint firstItem="u8N-gt-KTy" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.425" id="2br-Us-QB7"/>
                             <constraint firstAttribute="trailingMargin" secondItem="DY8-Xk-Z48" secondAttribute="trailing" id="3gF-IK-keB"/>
                             <constraint firstItem="DY8-Xk-Z48" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="DlY-6x-lHS"/>
-                            <constraint firstItem="nut-8U-Q0c" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="20" id="HbQ-5i-S0A"/>
-                            <constraint firstItem="u8N-gt-KTy" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="15" id="IDC-NM-JhA"/>
-                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="Xn7-bj-CGu" secondAttribute="bottom" constant="15" id="Ihj-oi-CgA"/>
+                            <constraint firstItem="nut-8U-Q0c" firstAttribute="top" secondItem="S6s-NX-1UC" secondAttribute="top" constant="20" id="HbQ-5i-S0A"/>
+                            <constraint firstItem="u8N-gt-KTy" firstAttribute="top" secondItem="S6s-NX-1UC" secondAttribute="top" constant="15" id="IDC-NM-JhA"/>
+                            <constraint firstItem="S6s-NX-1UC" firstAttribute="bottom" secondItem="Xn7-bj-CGu" secondAttribute="bottom" constant="15" id="Ihj-oi-CgA"/>
                             <constraint firstItem="u8N-gt-KTy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="nut-8U-Q0c" secondAttribute="trailing" constant="100" id="KfY-0b-thV"/>
                             <constraint firstAttribute="trailingMargin" secondItem="TWI-ht-Vhs" secondAttribute="trailing" constant="10" id="RSZ-oe-N98"/>
                             <constraint firstItem="u8N-gt-KTy" firstAttribute="height" secondItem="8bC-Xf-vdC" secondAttribute="height" multiplier="0.425" id="Ral-qt-gCK"/>
                             <constraint firstItem="IYV-Xb-1w3" firstAttribute="centerX" secondItem="Xn7-bj-CGu" secondAttribute="centerX" multiplier="1.066" id="TT6-Tc-36g"/>
-                            <constraint firstItem="u8N-gt-KTy" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" multiplier="1.15" id="TTg-10-bGD"/>
+                            <constraint firstItem="u8N-gt-KTy" firstAttribute="centerX" secondItem="S6s-NX-1UC" secondAttribute="centerX" multiplier="1.15" id="TTg-10-bGD"/>
                             <constraint firstItem="IYV-Xb-1w3" firstAttribute="centerY" secondItem="Xn7-bj-CGu" secondAttribute="centerY" id="VrA-YD-m0k"/>
                             <constraint firstAttribute="trailingMargin" secondItem="tml-7e-idc" secondAttribute="trailing" id="XiM-eJ-ye2"/>
                             <constraint firstItem="vn8-s2-SmV" firstAttribute="height" secondItem="u8N-gt-KTy" secondAttribute="height" multiplier="0.88" id="Ys9-17-eDl"/>
                             <constraint firstItem="IYV-Xb-1w3" firstAttribute="height" secondItem="Xn7-bj-CGu" secondAttribute="height" multiplier="0.95" id="bbO-kY-b7N"/>
                             <constraint firstItem="IYV-Xb-1w3" firstAttribute="width" secondItem="Xn7-bj-CGu" secondAttribute="width" multiplier="0.85" id="bsK-X6-kvg"/>
-                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="DY8-Xk-Z48" secondAttribute="bottom" id="d8j-yH-adg"/>
+                            <constraint firstItem="S6s-NX-1UC" firstAttribute="bottom" secondItem="DY8-Xk-Z48" secondAttribute="bottom" id="d8j-yH-adg"/>
                             <constraint firstItem="6u7-zE-DVc" firstAttribute="top" secondItem="tml-7e-idc" secondAttribute="bottom" constant="10" id="e9k-F9-thW"/>
                             <constraint firstItem="6u7-zE-DVc" firstAttribute="centerX" secondItem="tml-7e-idc" secondAttribute="centerX" id="kDd-z9-INh"/>
-                            <constraint firstItem="nut-8U-Q0c" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="20" id="keo-fh-FbU"/>
+                            <constraint firstItem="nut-8U-Q0c" firstAttribute="leading" secondItem="S6s-NX-1UC" secondAttribute="leading" constant="20" id="keo-fh-FbU"/>
                             <constraint firstItem="Xn7-bj-CGu" firstAttribute="height" secondItem="8bC-Xf-vdC" secondAttribute="height" multiplier="0.425" id="m1E-QE-Ksy"/>
                             <constraint firstItem="Xn7-bj-CGu" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.425" id="nKc-Sf-b6P"/>
                             <constraint firstItem="vn8-s2-SmV" firstAttribute="centerX" secondItem="u8N-gt-KTy" secondAttribute="centerX" multiplier="0.975" id="nSS-MO-8hh"/>
                             <constraint firstItem="vn8-s2-SmV" firstAttribute="width" secondItem="u8N-gt-KTy" secondAttribute="width" multiplier="0.8" id="rSA-d5-7UZ"/>
                             <constraint firstItem="vn8-s2-SmV" firstAttribute="centerY" secondItem="u8N-gt-KTy" secondAttribute="centerY" id="tMD-q5-x4C"/>
-                            <constraint firstItem="Xn7-bj-CGu" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" multiplier="0.85" id="vUM-Uk-xoQ"/>
-                            <constraint firstItem="DY8-Xk-Z48" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="vo3-Xh-zGI"/>
-                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="6u7-zE-DVc" secondAttribute="bottom" constant="10" id="vzD-ch-b2N"/>
-                            <constraint firstItem="TWI-ht-Vhs" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="10" id="wW0-cA-Zip"/>
+                            <constraint firstItem="Xn7-bj-CGu" firstAttribute="centerX" secondItem="S6s-NX-1UC" secondAttribute="centerX" multiplier="0.85" id="vUM-Uk-xoQ"/>
+                            <constraint firstItem="DY8-Xk-Z48" firstAttribute="top" secondItem="S6s-NX-1UC" secondAttribute="top" id="vo3-Xh-zGI"/>
+                            <constraint firstItem="S6s-NX-1UC" firstAttribute="bottom" secondItem="6u7-zE-DVc" secondAttribute="bottom" constant="10" id="vzD-ch-b2N"/>
+                            <constraint firstItem="TWI-ht-Vhs" firstAttribute="top" secondItem="S6s-NX-1UC" secondAttribute="top" constant="10" id="wW0-cA-Zip"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="S6s-NX-1UC"/>
                     </view>
                     <navigationItem key="navigationItem" title="Scene 1" id="cG0-Qh-xW1"/>
                     <connections>
@@ -652,14 +641,11 @@
         <scene sceneID="b2Q-yH-u8Q">
             <objects>
                 <viewController id="068-4x-alq" userLabel="MiniGameViewController" customClass="MiniGameViewController" customModule="Powerup" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="8yn-YN-bQt"/>
-                        <viewControllerLayoutGuide type="bottom" id="nnS-Sa-imG"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Jie-UC-Hrv" customClass="SKView">
                         <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <viewLayoutGuide key="safeArea" id="x8L-cn-gg8"/>
                     </view>
                     <navigationItem key="navigationItem" id="Wzd-hp-C7v"/>
                     <connections>
@@ -674,10 +660,6 @@
         <scene sceneID="uGO-Kb-Jms">
             <objects>
                 <viewController storyboardIdentifier="Shop View Controller" id="Ayb-3h-vA7" customClass="ShopViewController" customModule="Powerup" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="C1p-vc-PYe"/>
-                        <viewControllerLayoutGuide type="bottom" id="35U-NA-5dW"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="k8w-Nb-jCO">
                         <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -693,7 +675,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="18" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9IW-7K-Gls" userLabel="Karma Points Label">
-                                <rect key="frame" x="75" y="29.666666666666671" width="25.333333333333329" height="23.333333333333329"/>
+                                <rect key="frame" x="75" y="29" width="25.333333333333329" height="24.666666666666671"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="20"/>
                                 <color key="textColor" red="0.38069673900000001" green="0.59913557640000004" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -727,7 +709,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SELECT" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UT3-0Z-0jd" userLabel="Button Text">
-                                                        <rect key="frame" x="30.999999999999996" y="105.33333333333334" width="48.666666666666657" height="15.333333333333329"/>
+                                                        <rect key="frame" x="30.000000000000004" y="105" width="50.333333333333343" height="16"/>
                                                         <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="13"/>
                                                         <color key="textColor" red="0.38039215686274508" green="0.59999999999999998" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -784,7 +766,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2hB-Cx-GvA" userLabel="Button Text">
-                                                        <rect key="frame" x="36.666666666666686" y="105.33333333333334" width="36.666666666666657" height="15.333333333333329"/>
+                                                        <rect key="frame" x="34.333333333333371" y="105" width="41.333333333333343" height="16"/>
                                                         <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="13"/>
                                                         <color key="textColor" red="0.3803921569" green="0.59999999999999998" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -848,7 +830,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jJd-dk-a8M" userLabel="Button Text">
-                                                        <rect key="frame" x="37" y="105.33333333333334" width="36.666666666666657" height="15.333333333333329"/>
+                                                        <rect key="frame" x="34.666666666666629" y="105" width="41.333333333333343" height="16"/>
                                                         <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="13"/>
                                                         <color key="textColor" red="0.3803921569" green="0.59999999999999998" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -910,7 +892,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k4J-mj-DPt" userLabel="Button Text">
-                                                        <rect key="frame" x="37" y="104.99999999999997" width="36.666666666666657" height="15.333333333333329"/>
+                                                        <rect key="frame" x="34.666666666666657" y="104.66666666666666" width="41.333333333333343" height="16"/>
                                                         <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="13"/>
                                                         <color key="textColor" red="0.3803921569" green="0.59999999999999998" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -967,7 +949,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6uT-um-xmX" userLabel="Button Text">
-                                                        <rect key="frame" x="36.666666666666686" y="104.99999999999997" width="36.666666666666657" height="15.333333333333329"/>
+                                                        <rect key="frame" x="34.333333333333371" y="104.66666666666666" width="41.333333333333343" height="16"/>
                                                         <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="13"/>
                                                         <color key="textColor" red="0.3803921569" green="0.59999999999999998" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -1024,7 +1006,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UQo-Hs-1Vo" userLabel="Button Text">
-                                                        <rect key="frame" x="37" y="104.99999999999997" width="36.666666666666657" height="15.333333333333329"/>
+                                                        <rect key="frame" x="34.666666666666629" y="104.66666666666666" width="41.333333333333343" height="16"/>
                                                         <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="13"/>
                                                         <color key="textColor" red="0.3803921569" green="0.59999999999999998" blue="0.69288374350000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -1162,7 +1144,7 @@
                             <constraint firstItem="Zb4-CC-Mbj" firstAttribute="leading" secondItem="NR8-TQ-vgw" secondAttribute="trailing" constant="20" id="38P-wd-o9F"/>
                             <constraint firstItem="24j-Zk-rSY" firstAttribute="leading" secondItem="k8w-Nb-jCO" secondAttribute="leadingMargin" id="E7y-vs-NkD"/>
                             <constraint firstItem="QNs-33-Qom" firstAttribute="centerX" secondItem="uOc-oZ-NLG" secondAttribute="centerX" multiplier="0.875" id="Eqb-89-u1L"/>
-                            <constraint firstItem="35U-NA-5dW" firstAttribute="top" secondItem="dpd-4J-5ix" secondAttribute="bottom" id="F59-U3-8T4"/>
+                            <constraint firstItem="1QP-Fe-3E2" firstAttribute="bottom" secondItem="dpd-4J-5ix" secondAttribute="bottom" id="F59-U3-8T4"/>
                             <constraint firstItem="QNs-33-Qom" firstAttribute="width" secondItem="uOc-oZ-NLG" secondAttribute="width" multiplier="0.275" id="KjK-7F-OAn"/>
                             <constraint firstItem="JQp-zY-86c" firstAttribute="width" secondItem="uOc-oZ-NLG" secondAttribute="width" multiplier="0.25" id="KrV-Eu-QSt"/>
                             <constraint firstItem="0A7-Zd-dwO" firstAttribute="top" secondItem="24j-Zk-rSY" secondAttribute="bottom" constant="74" id="LUW-xc-D7c"/>
@@ -1174,12 +1156,12 @@
                             <constraint firstItem="NR8-TQ-vgw" firstAttribute="leading" relation="lessThanOrEqual" secondItem="0A7-Zd-dwO" secondAttribute="trailing" constant="102.33" id="U5i-fH-Jhx"/>
                             <constraint firstItem="9IW-7K-Gls" firstAttribute="centerY" secondItem="24j-Zk-rSY" secondAttribute="centerY" id="VtM-Jz-htp"/>
                             <constraint firstItem="QNs-33-Qom" firstAttribute="height" secondItem="uOc-oZ-NLG" secondAttribute="height" id="W0D-qF-cTh"/>
-                            <constraint firstAttribute="trailing" secondItem="dpd-4J-5ix" secondAttribute="trailing" id="Xqe-lv-jvl"/>
+                            <constraint firstItem="1QP-Fe-3E2" firstAttribute="trailing" secondItem="dpd-4J-5ix" secondAttribute="trailing" id="Xqe-lv-jvl"/>
                             <constraint firstItem="uOc-oZ-NLG" firstAttribute="centerY" secondItem="k8w-Nb-jCO" secondAttribute="centerY" multiplier="0.2" id="YJe-bm-Xh6"/>
                             <constraint firstItem="JQp-zY-86c" firstAttribute="centerX" secondItem="uOc-oZ-NLG" secondAttribute="centerX" multiplier="0.55" id="bWL-n1-CRv"/>
-                            <constraint firstItem="uOc-oZ-NLG" firstAttribute="centerX" secondItem="k8w-Nb-jCO" secondAttribute="centerX" id="gQf-bi-4TF"/>
-                            <constraint firstItem="NR8-TQ-vgw" firstAttribute="centerX" secondItem="k8w-Nb-jCO" secondAttribute="centerX" multiplier="1.15" id="hIO-OW-zYh"/>
-                            <constraint firstItem="DHw-1J-Sgi" firstAttribute="top" secondItem="C1p-vc-PYe" secondAttribute="bottom" constant="12" id="kW5-QP-L1V"/>
+                            <constraint firstItem="uOc-oZ-NLG" firstAttribute="centerX" secondItem="1QP-Fe-3E2" secondAttribute="centerX" id="gQf-bi-4TF"/>
+                            <constraint firstItem="NR8-TQ-vgw" firstAttribute="centerX" secondItem="1QP-Fe-3E2" secondAttribute="centerX" multiplier="1.15" id="hIO-OW-zYh"/>
+                            <constraint firstItem="DHw-1J-Sgi" firstAttribute="top" secondItem="1QP-Fe-3E2" secondAttribute="top" constant="12" id="kW5-QP-L1V"/>
                             <constraint firstItem="24j-Zk-rSY" firstAttribute="centerY" secondItem="uOc-oZ-NLG" secondAttribute="centerY" id="lDB-2M-yWU"/>
                             <constraint firstItem="de7-VX-YPL" firstAttribute="centerY" secondItem="uOc-oZ-NLG" secondAttribute="centerY" id="lcn-0X-bXk"/>
                             <constraint firstItem="Zb4-CC-Mbj" firstAttribute="centerY" secondItem="NR8-TQ-vgw" secondAttribute="centerY" id="nJ5-C6-bN7"/>
@@ -1190,11 +1172,12 @@
                             <constraint firstItem="0A7-Zd-dwO" firstAttribute="leading" secondItem="k8w-Nb-jCO" secondAttribute="leadingMargin" constant="10" id="tej-Cq-MEH"/>
                             <constraint firstItem="NR8-TQ-vgw" firstAttribute="width" secondItem="k8w-Nb-jCO" secondAttribute="width" multiplier="0.6" id="uNi-cP-zpo"/>
                             <constraint firstItem="de7-VX-YPL" firstAttribute="centerX" secondItem="uOc-oZ-NLG" secondAttribute="centerX" multiplier="1.325" id="wND-ca-En7"/>
-                            <constraint firstItem="dpd-4J-5ix" firstAttribute="top" secondItem="C1p-vc-PYe" secondAttribute="bottom" id="wiQ-iN-zee"/>
+                            <constraint firstItem="dpd-4J-5ix" firstAttribute="top" secondItem="1QP-Fe-3E2" secondAttribute="top" id="wiQ-iN-zee"/>
                             <constraint firstItem="de7-VX-YPL" firstAttribute="width" secondItem="uOc-oZ-NLG" secondAttribute="width" multiplier="0.425" id="xGs-lH-WVi"/>
                             <constraint firstItem="de7-VX-YPL" firstAttribute="height" secondItem="uOc-oZ-NLG" secondAttribute="height" id="xO8-we-Hf1"/>
-                            <constraint firstItem="dpd-4J-5ix" firstAttribute="leading" secondItem="k8w-Nb-jCO" secondAttribute="leading" id="zBI-gr-IyB"/>
+                            <constraint firstItem="dpd-4J-5ix" firstAttribute="leading" secondItem="1QP-Fe-3E2" secondAttribute="leading" id="zBI-gr-IyB"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="1QP-Fe-3E2"/>
                     </view>
                     <navigationItem key="navigationItem" id="D4F-cd-wPJ"/>
                     <connections>
@@ -1256,10 +1239,6 @@
         <scene sceneID="7iy-JJ-2EY">
             <objects>
                 <viewController storyboardIdentifier="Results View Controller" id="Kej-3M-rbU" customClass="ResultsViewController" customModule="Powerup" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="niI-hx-Uj2"/>
-                        <viewControllerLayoutGuide type="bottom" id="j4y-Z7-O5g"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="5cF-Xa-Kzb">
                         <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1365,22 +1344,23 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="LCU-a0-55m" firstAttribute="leading" secondItem="Be8-ZB-uyt" secondAttribute="leading" id="0aK-OI-CRi"/>
-                            <constraint firstAttribute="trailing" secondItem="hkc-WO-sSi" secondAttribute="trailing" id="2U3-Jl-c0b"/>
+                            <constraint firstItem="PhL-0E-f2r" firstAttribute="trailing" secondItem="hkc-WO-sSi" secondAttribute="trailing" id="2U3-Jl-c0b"/>
                             <constraint firstItem="LCU-a0-55m" firstAttribute="trailing" secondItem="hkc-WO-sSi" secondAttribute="trailing" id="7fn-lE-QEL"/>
-                            <constraint firstItem="dAT-bp-U9O" firstAttribute="centerX" secondItem="5cF-Xa-Kzb" secondAttribute="centerX" id="7zQ-zy-GG6"/>
+                            <constraint firstItem="dAT-bp-U9O" firstAttribute="centerX" secondItem="PhL-0E-f2r" secondAttribute="centerX" id="7zQ-zy-GG6"/>
                             <constraint firstItem="9eA-5h-upJ" firstAttribute="centerX" secondItem="Be8-ZB-uyt" secondAttribute="centerX" multiplier="1.35" id="HH4-n1-TzV"/>
                             <constraint firstItem="9eA-5h-upJ" firstAttribute="centerY" secondItem="Be8-ZB-uyt" secondAttribute="centerY" multiplier="1.3" id="Huv-Vf-A5Z"/>
                             <constraint firstItem="dAT-bp-U9O" firstAttribute="top" secondItem="LCU-a0-55m" secondAttribute="bottom" constant="11" id="K1e-4W-kpF"/>
-                            <constraint firstItem="Be8-ZB-uyt" firstAttribute="leading" secondItem="5cF-Xa-Kzb" secondAttribute="leading" id="O5X-Xw-Qoy"/>
-                            <constraint firstItem="Be8-ZB-uyt" firstAttribute="top" secondItem="niI-hx-Uj2" secondAttribute="bottom" id="Pab-Rm-KFC"/>
+                            <constraint firstItem="Be8-ZB-uyt" firstAttribute="leading" secondItem="PhL-0E-f2r" secondAttribute="leading" id="O5X-Xw-Qoy"/>
+                            <constraint firstItem="Be8-ZB-uyt" firstAttribute="top" secondItem="PhL-0E-f2r" secondAttribute="top" id="Pab-Rm-KFC"/>
                             <constraint firstItem="GJ2-0z-LHF" firstAttribute="centerY" secondItem="Be8-ZB-uyt" secondAttribute="centerY" multiplier="1.3" id="Uzl-Eu-AG3"/>
                             <constraint firstItem="LCU-a0-55m" firstAttribute="top" secondItem="Be8-ZB-uyt" secondAttribute="top" id="XCp-DW-Adh"/>
                             <constraint firstItem="dAT-bp-U9O" firstAttribute="centerY" secondItem="5cF-Xa-Kzb" secondAttribute="centerY" multiplier="0.5" id="esw-iU-UsW"/>
-                            <constraint firstAttribute="trailing" secondItem="Be8-ZB-uyt" secondAttribute="trailing" id="fNw-M8-vNI"/>
-                            <constraint firstItem="j4y-Z7-O5g" firstAttribute="top" secondItem="Be8-ZB-uyt" secondAttribute="bottom" id="ftf-af-57d"/>
-                            <constraint firstItem="j4y-Z7-O5g" firstAttribute="top" secondItem="hkc-WO-sSi" secondAttribute="bottom" constant="45" id="gpI-A9-kvx"/>
+                            <constraint firstItem="PhL-0E-f2r" firstAttribute="trailing" secondItem="Be8-ZB-uyt" secondAttribute="trailing" id="fNw-M8-vNI"/>
+                            <constraint firstItem="PhL-0E-f2r" firstAttribute="bottom" secondItem="Be8-ZB-uyt" secondAttribute="bottom" id="ftf-af-57d"/>
+                            <constraint firstItem="PhL-0E-f2r" firstAttribute="bottom" secondItem="hkc-WO-sSi" secondAttribute="bottom" constant="45" id="gpI-A9-kvx"/>
                             <constraint firstItem="GJ2-0z-LHF" firstAttribute="centerX" secondItem="Be8-ZB-uyt" secondAttribute="centerX" multiplier="0.65" id="onM-Ok-20z"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="PhL-0E-f2r"/>
                     </view>
                     <navigationItem key="navigationItem" id="3kO-Pm-0qg"/>
                     <connections>
@@ -1400,10 +1380,6 @@
         <scene sceneID="KiG-y7-maB">
             <objects>
                 <viewController id="rlW-vW-5EN" customClass="CompletedViewController" customModule="Powerup" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="niH-gG-daI"/>
-                        <viewControllerLayoutGuide type="bottom" id="dlx-sJ-h6W"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="uPm-ct-ZVH">
                         <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1499,20 +1475,21 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="o1p-K2-wtC" firstAttribute="height" secondItem="uPm-ct-ZVH" secondAttribute="height" id="3wD-gh-VXD"/>
-                            <constraint firstItem="o1p-K2-wtC" firstAttribute="centerX" secondItem="uPm-ct-ZVH" secondAttribute="centerX" id="9Tb-CR-JEO"/>
+                            <constraint firstItem="o1p-K2-wtC" firstAttribute="centerX" secondItem="kf5-k4-P7P" secondAttribute="centerX" id="9Tb-CR-JEO"/>
                             <constraint firstItem="3x2-5c-b2v" firstAttribute="top" secondItem="4p4-11-KM4" secondAttribute="bottom" constant="11" id="AYW-9e-dcl"/>
                             <constraint firstItem="4p4-11-KM4" firstAttribute="trailing" secondItem="o1p-K2-wtC" secondAttribute="trailing" id="Ujb-7P-mRB"/>
                             <constraint firstItem="ggV-oD-bbd" firstAttribute="centerY" secondItem="o1p-K2-wtC" secondAttribute="centerY" multiplier="1.3" id="VpX-9o-3dH"/>
                             <constraint firstItem="4p4-11-KM4" firstAttribute="top" secondItem="o1p-K2-wtC" secondAttribute="top" id="YXU-HK-Qfq"/>
                             <constraint firstItem="3x2-5c-b2v" firstAttribute="centerY" secondItem="uPm-ct-ZVH" secondAttribute="centerY" multiplier="0.5" id="cIj-uW-oMi"/>
-                            <constraint firstItem="NFe-EU-XXC" firstAttribute="centerX" secondItem="uPm-ct-ZVH" secondAttribute="centerX" multiplier="1.35" id="fKW-c3-UtX"/>
+                            <constraint firstItem="NFe-EU-XXC" firstAttribute="centerX" secondItem="kf5-k4-P7P" secondAttribute="centerX" multiplier="1.35" id="fKW-c3-UtX"/>
                             <constraint firstItem="ggV-oD-bbd" firstAttribute="centerX" secondItem="o1p-K2-wtC" secondAttribute="centerX" multiplier="0.65" id="j5U-Yf-1jk"/>
                             <constraint firstItem="o1p-K2-wtC" firstAttribute="centerY" secondItem="uPm-ct-ZVH" secondAttribute="centerY" id="jji-0E-Qlf"/>
                             <constraint firstItem="NFe-EU-XXC" firstAttribute="centerY" secondItem="uPm-ct-ZVH" secondAttribute="centerY" multiplier="1.3" id="kIk-uK-KmT"/>
                             <constraint firstItem="o1p-K2-wtC" firstAttribute="width" secondItem="uPm-ct-ZVH" secondAttribute="width" id="nCx-ib-BIm"/>
                             <constraint firstItem="4p4-11-KM4" firstAttribute="leading" secondItem="o1p-K2-wtC" secondAttribute="leading" id="rxz-SU-qol"/>
-                            <constraint firstItem="3x2-5c-b2v" firstAttribute="centerX" secondItem="uPm-ct-ZVH" secondAttribute="centerX" id="y64-1S-zIE"/>
+                            <constraint firstItem="3x2-5c-b2v" firstAttribute="centerX" secondItem="kf5-k4-P7P" secondAttribute="centerX" id="y64-1S-zIE"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="kf5-k4-P7P"/>
                     </view>
                     <navigationItem key="navigationItem" id="QiI-9m-e9X"/>
                     <connections>
@@ -1529,10 +1506,6 @@
         <scene sceneID="8zi-ZT-9cM">
             <objects>
                 <viewController storyboardIdentifier="2" id="S3c-uW-lpA" userLabel="MapViewController" customClass="MapViewController" customModule="Powerup" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="a2t-1i-ibK"/>
-                        <viewControllerLayoutGuide type="bottom" id="1Sr-V8-zvm"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="qU0-tn-cF3">
                         <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1620,18 +1593,18 @@
                             <constraint firstItem="Wu8-rw-HXZ" firstAttribute="leading" secondItem="tPY-8j-neT" secondAttribute="trailing" multiplier="0.045" constant="8" symbolic="YES" id="8Ws-f0-fc3"/>
                             <constraint firstItem="ZEg-pi-KP9" firstAttribute="width" secondItem="tPY-8j-neT" secondAttribute="width" id="8ns-PQ-cke"/>
                             <constraint firstItem="Fmy-iT-ufw" firstAttribute="centerX" secondItem="tPY-8j-neT" secondAttribute="centerX" id="9eG-mb-MZP"/>
-                            <constraint firstItem="bQW-Ca-CzZ" firstAttribute="top" secondItem="a2t-1i-ibK" secondAttribute="bottom" constant="5" id="Brr-JA-TGg"/>
+                            <constraint firstItem="bQW-Ca-CzZ" firstAttribute="top" secondItem="3aq-0L-tMs" secondAttribute="top" constant="5" id="Brr-JA-TGg"/>
                             <constraint firstItem="Wu8-rw-HXZ" firstAttribute="top" secondItem="tPY-8j-neT" secondAttribute="bottom" multiplier="0.07" id="Cdr-nl-FIo"/>
                             <constraint firstItem="571-Oe-vdt" firstAttribute="top" secondItem="tPY-8j-neT" secondAttribute="bottom" multiplier="0.25" id="IhJ-2P-Ocz"/>
-                            <constraint firstItem="1Sr-V8-zvm" firstAttribute="top" secondItem="tPY-8j-neT" secondAttribute="bottom" id="Jlj-tY-ptq"/>
+                            <constraint firstItem="3aq-0L-tMs" firstAttribute="bottom" secondItem="tPY-8j-neT" secondAttribute="bottom" id="Jlj-tY-ptq"/>
                             <constraint firstItem="571-Oe-vdt" firstAttribute="width" secondItem="tPY-8j-neT" secondAttribute="width" multiplier="0.21" id="JrH-FO-4gW"/>
                             <constraint firstItem="Wu8-rw-HXZ" firstAttribute="height" secondItem="tPY-8j-neT" secondAttribute="height" multiplier="0.35" id="KgZ-4L-GaX"/>
                             <constraint firstItem="Ywa-nu-uIK" firstAttribute="width" secondItem="tPY-8j-neT" secondAttribute="width" multiplier="0.22" id="NlP-Wo-uFv"/>
-                            <constraint firstItem="tPY-8j-neT" firstAttribute="top" secondItem="a2t-1i-ibK" secondAttribute="bottom" id="QMJ-dZ-gRV"/>
+                            <constraint firstItem="tPY-8j-neT" firstAttribute="top" secondItem="3aq-0L-tMs" secondAttribute="top" id="QMJ-dZ-gRV"/>
                             <constraint firstItem="ZEg-pi-KP9" firstAttribute="centerY" secondItem="tPY-8j-neT" secondAttribute="centerY" id="TGg-6A-tyw"/>
                             <constraint firstItem="voa-Rz-4F0" firstAttribute="centerX" secondItem="tPY-8j-neT" secondAttribute="centerX" id="TVe-VT-tdJ"/>
                             <constraint firstItem="voa-Rz-4F0" firstAttribute="centerY" secondItem="tPY-8j-neT" secondAttribute="centerY" id="YPK-d9-N3h"/>
-                            <constraint firstAttribute="trailing" secondItem="tPY-8j-neT" secondAttribute="trailing" id="ZP0-zC-i5Q"/>
+                            <constraint firstItem="3aq-0L-tMs" firstAttribute="trailing" secondItem="tPY-8j-neT" secondAttribute="trailing" id="ZP0-zC-i5Q"/>
                             <constraint firstItem="b9k-wY-tNO" firstAttribute="leading" secondItem="tPY-8j-neT" secondAttribute="trailing" multiplier="0.03" id="cNF-AK-697"/>
                             <constraint firstItem="Ywa-nu-uIK" firstAttribute="height" secondItem="tPY-8j-neT" secondAttribute="height" multiplier="0.35" id="e9e-tR-vIS"/>
                             <constraint firstItem="Fmy-iT-ufw" firstAttribute="width" secondItem="tPY-8j-neT" secondAttribute="width" id="eYt-FY-mq7"/>
@@ -1639,20 +1612,21 @@
                             <constraint firstItem="5zf-M3-jE6" firstAttribute="top" secondItem="tPY-8j-neT" secondAttribute="bottom" multiplier="0.5" id="hqv-cc-dfA"/>
                             <constraint firstItem="Wu8-rw-HXZ" firstAttribute="width" secondItem="tPY-8j-neT" secondAttribute="width" multiplier="0.3" id="i50-Bc-EcL"/>
                             <constraint firstItem="571-Oe-vdt" firstAttribute="height" secondItem="tPY-8j-neT" secondAttribute="height" multiplier="0.35" id="kcq-6x-7Hn"/>
-                            <constraint firstAttribute="trailing" secondItem="bQW-Ca-CzZ" secondAttribute="trailing" constant="5" id="l8B-hE-E3U"/>
+                            <constraint firstItem="3aq-0L-tMs" firstAttribute="trailing" secondItem="bQW-Ca-CzZ" secondAttribute="trailing" constant="5" id="l8B-hE-E3U"/>
                             <constraint firstItem="571-Oe-vdt" firstAttribute="leading" secondItem="tPY-8j-neT" secondAttribute="trailing" multiplier="0.38" id="nn5-gf-nwK"/>
                             <constraint firstItem="5zf-M3-jE6" firstAttribute="leading" secondItem="tPY-8j-neT" secondAttribute="trailing" multiplier="0.7" id="p2S-Zb-bMC"/>
                             <constraint firstItem="voa-Rz-4F0" firstAttribute="height" secondItem="tPY-8j-neT" secondAttribute="height" id="qYM-5C-pai"/>
                             <constraint firstItem="ZEg-pi-KP9" firstAttribute="centerX" secondItem="tPY-8j-neT" secondAttribute="centerX" id="rCL-ba-Lc2"/>
                             <constraint firstItem="5zf-M3-jE6" firstAttribute="width" secondItem="tPY-8j-neT" secondAttribute="width" multiplier="0.27" id="rEp-Z8-th6"/>
                             <constraint firstItem="b9k-wY-tNO" firstAttribute="width" secondItem="tPY-8j-neT" secondAttribute="width" multiplier="0.15" id="sBl-Cr-Waf"/>
-                            <constraint firstItem="tPY-8j-neT" firstAttribute="leading" secondItem="qU0-tn-cF3" secondAttribute="leading" id="t76-5m-VBT"/>
+                            <constraint firstItem="tPY-8j-neT" firstAttribute="leading" secondItem="3aq-0L-tMs" secondAttribute="leading" id="t76-5m-VBT"/>
                             <constraint firstItem="5zf-M3-jE6" firstAttribute="height" secondItem="tPY-8j-neT" secondAttribute="height" multiplier="0.5" id="uK7-Ao-pCV"/>
                             <constraint firstItem="Fmy-iT-ufw" firstAttribute="centerY" secondItem="tPY-8j-neT" secondAttribute="centerY" id="ueX-HO-LDJ"/>
                             <constraint firstItem="ZEg-pi-KP9" firstAttribute="height" secondItem="tPY-8j-neT" secondAttribute="height" id="we1-Lk-rY6"/>
                             <constraint firstItem="voa-Rz-4F0" firstAttribute="width" secondItem="tPY-8j-neT" secondAttribute="width" id="xvv-Rk-sWn"/>
                             <constraint firstItem="Ywa-nu-uIK" firstAttribute="leading" secondItem="tPY-8j-neT" secondAttribute="trailing" multiplier="0.7" id="yKW-Sx-C55"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="3aq-0L-tMs"/>
                     </view>
                     <navigationItem key="navigationItem" id="jFe-nm-wls"/>
                     <connections>
@@ -1692,10 +1666,6 @@
         <scene sceneID="nn6-Fo-6ig">
             <objects>
                 <viewController id="5Pu-6a-xWp" customClass="EndViewController" customModule="Powerup" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="MB6-Ym-i65"/>
-                        <viewControllerLayoutGuide type="bottom" id="Gkg-bt-3iZ"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="jQo-by-wdf">
                         <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1750,22 +1720,23 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="UMB-Yq-rOx" firstAttribute="centerY" secondItem="jQo-by-wdf" secondAttribute="centerY" constant="40" id="3Jb-UE-y76"/>
-                            <constraint firstItem="GqS-kL-Xqm" firstAttribute="leading" secondItem="jQo-by-wdf" secondAttribute="leading" id="54S-yj-VEr"/>
-                            <constraint firstItem="wyS-fw-fBB" firstAttribute="centerX" secondItem="jQo-by-wdf" secondAttribute="centerX" id="Ci9-ew-47z"/>
-                            <constraint firstItem="GqS-kL-Xqm" firstAttribute="top" secondItem="MB6-Ym-i65" secondAttribute="bottom" id="Ns9-UV-pGs"/>
+                            <constraint firstItem="GqS-kL-Xqm" firstAttribute="leading" secondItem="ucy-dB-Hec" secondAttribute="leading" id="54S-yj-VEr"/>
+                            <constraint firstItem="wyS-fw-fBB" firstAttribute="centerX" secondItem="ucy-dB-Hec" secondAttribute="centerX" id="Ci9-ew-47z"/>
+                            <constraint firstItem="GqS-kL-Xqm" firstAttribute="top" secondItem="ucy-dB-Hec" secondAttribute="top" id="Ns9-UV-pGs"/>
                             <constraint firstItem="OdA-pZ-nes" firstAttribute="leading" secondItem="jQo-by-wdf" secondAttribute="leadingMargin" constant="-10" id="QIL-BQ-y1B"/>
                             <constraint firstItem="aI2-xc-czF" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iWP-8n-6F6" secondAttribute="trailing" constant="500" id="Qjc-FI-10e"/>
                             <constraint firstItem="iWP-8n-6F6" firstAttribute="leading" secondItem="OdA-pZ-nes" secondAttribute="trailing" constant="10" id="SUc-3o-wRf"/>
-                            <constraint firstItem="UMB-Yq-rOx" firstAttribute="centerX" secondItem="jQo-by-wdf" secondAttribute="centerX" id="Yba-jx-cz7"/>
-                            <constraint firstItem="OdA-pZ-nes" firstAttribute="top" secondItem="MB6-Ym-i65" secondAttribute="bottom" constant="10" id="e4Z-3A-1Df"/>
-                            <constraint firstItem="aI2-xc-czF" firstAttribute="top" secondItem="MB6-Ym-i65" secondAttribute="bottom" constant="15" id="fCK-DX-80A"/>
-                            <constraint firstItem="iWP-8n-6F6" firstAttribute="top" secondItem="MB6-Ym-i65" secondAttribute="bottom" constant="13" id="gjr-2I-hj1"/>
-                            <constraint firstAttribute="trailing" secondItem="GqS-kL-Xqm" secondAttribute="trailing" id="iwm-B1-9Uf"/>
-                            <constraint firstItem="GqS-kL-Xqm" firstAttribute="bottom" secondItem="Gkg-bt-3iZ" secondAttribute="top" id="jIA-LW-T2X"/>
+                            <constraint firstItem="UMB-Yq-rOx" firstAttribute="centerX" secondItem="ucy-dB-Hec" secondAttribute="centerX" id="Yba-jx-cz7"/>
+                            <constraint firstItem="OdA-pZ-nes" firstAttribute="top" secondItem="ucy-dB-Hec" secondAttribute="top" constant="10" id="e4Z-3A-1Df"/>
+                            <constraint firstItem="aI2-xc-czF" firstAttribute="top" secondItem="ucy-dB-Hec" secondAttribute="top" constant="15" id="fCK-DX-80A"/>
+                            <constraint firstItem="iWP-8n-6F6" firstAttribute="top" secondItem="ucy-dB-Hec" secondAttribute="top" constant="13" id="gjr-2I-hj1"/>
+                            <constraint firstItem="ucy-dB-Hec" firstAttribute="trailing" secondItem="GqS-kL-Xqm" secondAttribute="trailing" id="iwm-B1-9Uf"/>
+                            <constraint firstItem="GqS-kL-Xqm" firstAttribute="bottom" secondItem="ucy-dB-Hec" secondAttribute="bottom" id="jIA-LW-T2X"/>
                             <constraint firstItem="wyS-fw-fBB" firstAttribute="centerY" secondItem="jQo-by-wdf" secondAttribute="centerY" constant="-20" id="n5Y-BG-NY9"/>
                             <constraint firstAttribute="trailingMargin" secondItem="aI2-xc-czF" secondAttribute="trailing" constant="10" id="tJ2-52-vLo"/>
                             <constraint firstItem="OdA-pZ-nes" firstAttribute="centerY" secondItem="iWP-8n-6F6" secondAttribute="centerY" id="zn1-A7-8Kq"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="ucy-dB-Hec"/>
                     </view>
                     <navigationItem key="navigationItem" id="O4f-Ov-czj"/>
                     <connections>
@@ -1813,7 +1784,7 @@
         <image name="start_scene" width="682.66668701171875" height="384"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="Ck5-aV-1L2"/>
+        <segue reference="Vcg-vV-Did"/>
         <segue reference="HHh-kx-uKw"/>
         <segue reference="1yy-KV-VO2"/>
     </inferredMetricsTieBreakers>


### PR DESCRIPTION
### Description
I change the Position of Continue Button which is present in Customize Avatar View. Using safe area alignment guide.
Fixes #327

![power](https://user-images.githubusercontent.com/47811606/73598647-036f6e00-4561-11ea-8778-d071f27d6865.png)






### Type of Change:

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

- New feature (non-breaking change which adds functionality pre-approved by mentors)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works


- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
