### PR TITLE
Requesting App Ratings

### DIFF
--- a/AppStoreReviewManager.swift
+++ b/AppStoreReviewManager.swift
@@ -1,17 +1,50 @@
 //
 //  AppStoreReviewManager.swift
 //  Powerup
-
 import Foundation
 
 import StoreKit
 
 enum AppStoreReviewManager {
+  
+  static let minimumReviewWorthyActionCount = 4
+
+  static func requestReviewIfAppropriate() {
+    let defaults = UserDefaults.standard
+    let bundle = Bundle.main
+
+    // Read the current number of actions that the user has performed since the last requested review from the User Defaults.
     
-    static func requestReviewIfAppropriate() {
-        
-        // funcion for Requesting App Ratings
-        SKStoreReviewController.requestReview()
-        
+    var actionCount = defaults.integer(forKey: .reviewWorthyActionCount)
+    
+  /*  Note: This sample project uses an extension on UserDefaults to eliminate the need for using “stringly” typed keys when accessing values. This is a good practice to follow in order to avoid accidentally mistyping a key as it can cause hard-to-find bugs in your app. You can find this extension in UserDefaults+Key.swift.
+ */
+    
+    actionCount += 1
+
+    defaults.set(actionCount, forKey: .reviewWorthyActionCount)
+
+    guard actionCount >= minimumReviewWorthyActionCount else {
+      return
     }
+    
+    let bundleVersionKey = kCFBundleVersionKey as String
+    let currentVersion = bundle.object(forInfoDictionaryKey: bundleVersionKey) as? String
+    let lastVersion = defaults.string(forKey: .lastReviewRequestAppVersion)
+
+    // Check if this is the first request for this version of the app before continuing.
+    guard lastVersion == nil || lastVersion != currentVersion else {
+      return
+    }
+
+    SKStoreReviewController.requestReview()
+
+    // Reset the action count and store the current version in User Defaults so that you don’t request again on this version of the app.
+    defaults.set(0, forKey: .reviewWorthyActionCount)
+    defaults.set(currentVersion, forKey: .lastReviewRequestAppVersion)
+  }
+  
+  
 }
+
+

--- a/AppStoreReviewManager.swift
+++ b/AppStoreReviewManager.swift
@@ -1,0 +1,17 @@
+//
+//  AppStoreReviewManager.swift
+//  Powerup
+
+import Foundation
+
+import StoreKit
+
+enum AppStoreReviewManager {
+    
+    static func requestReviewIfAppropriate() {
+        
+        // funcion for Requesting App Ratings
+        SKStoreReviewController.requestReview()
+        
+    }
+}

--- a/Powerup.xcodeproj/project.pbxproj
+++ b/Powerup.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		D9E74B7F1F1F1AF800A42B7E /* VocabMatchingTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E74B7E1F1F1AF800A42B7E /* VocabMatchingTile.swift */; };
 		D9E922E71F1C9FFA0091D8BB /* SinkToSwimTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E922E61F1C9FFA0091D8BB /* SinkToSwimTests.swift */; };
 		D9EEC4551F2A1A230037C745 /* VocabMatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EEC4541F2A1A230037C745 /* VocabMatchingTests.swift */; };
+		E685365323F2E65E005775E6 /* AppStoreReviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E685365223F2E65E005775E6 /* AppStoreReviewManager.swift */; };
 		EAB1B4AC1FE9E4FB005964AF /* UserDefaultsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB1B4AB1FE9E4FB005964AF /* UserDefaultsHandler.swift */; };
 /* End PBXBuildFile section */
 
@@ -209,6 +210,7 @@
 		D9E74B7E1F1F1AF800A42B7E /* VocabMatchingTile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VocabMatchingTile.swift; sourceTree = "<group>"; };
 		D9E922E61F1C9FFA0091D8BB /* SinkToSwimTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SinkToSwimTests.swift; sourceTree = "<group>"; };
 		D9EEC4541F2A1A230037C745 /* VocabMatchingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VocabMatchingTests.swift; sourceTree = "<group>"; };
+		E685365223F2E65E005775E6 /* AppStoreReviewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreReviewManager.swift; sourceTree = "<group>"; };
 		EAB1B4AB1FE9E4FB005964AF /* UserDefaultsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsHandler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -241,6 +243,7 @@
 		2A0CA5461B294C6B00ED8781 = {
 			isa = PBXGroup;
 			children = (
+				E685365223F2E65E005775E6 /* AppStoreReviewManager.swift */,
 				2AC905691CDB445B00FFA856 /* FMDB */,
 				2AD1A1E61B2B1ADA00BCA94D /* ModelManager.swift */,
 				2A0CA5741B294C9200ED8781 /* libsqlite3.dylib */,
@@ -632,6 +635,7 @@
 				2AF82A901B4BA74A00307BED /* FMDatabaseQueue.m in Sources */,
 				2AF82A911B4BA74A00307BED /* FMResultSet.m in Sources */,
 				2AF82A8F1B4BA74A00307BED /* FMDatabasePool.m in Sources */,
+				E685365323F2E65E005775E6 /* AppStoreReviewManager.swift in Sources */,
 				D959CBC71EE6430E00C31753 /* Answer.swift in Sources */,
 				2A8D2E071D17CDF700154F98 /* ShopViewController.swift in Sources */,
 				D9AAA9C61EF2481900287A79 /* GuessingBox.swift in Sources */,
@@ -852,6 +856,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = MZWL92LA7S;
 				INFOPLIST_FILE = Powerup/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -876,6 +881,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = MZWL92LA7S;
 				INFOPLIST_FILE = Powerup/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/Powerup/SinkToSwimGameScene.swift
+++ b/Powerup/SinkToSwimGameScene.swift
@@ -445,6 +445,7 @@ class SinkToSwimGameScene: SKScene {
             
             // Game over.
             gameOver(drowned: false)
+          
         }
         
         if isGameOver { return }
@@ -526,6 +527,9 @@ class SinkToSwimGameScene: SKScene {
     func gameOver(drowned: Bool) {
         isGameOver = true
         
+        // calling requestReviewIfAppropriate function for request to review Powerup
+        AppStoreReviewManager.requestReviewIfAppropriate()
+        
         // Stop the timer ticking animation.
         removeAction(forKey: "timer_tick")
         
@@ -543,7 +547,9 @@ class SinkToSwimGameScene: SKScene {
             self.endSceneSprite.run(SKAction.fadeIn(withDuration: self.endSceneFadeInDuration)) {
                 self.continueButtonInteractable = true
             }
+        
         }
+     
     }
     
     // Fade-in the next question.
@@ -622,10 +628,13 @@ class SinkToSwimGameScene: SKScene {
                 viewController.score = score
                 // End game.
                 viewController.endGame()
+              
             }
             
             // Disable true/false/dont know buttons if the game is over.
             return
+            
+           
         }
         
         let location = touch.location(in: questionBoxSprite)

--- a/Powerup/SinkToSwimGameScene.swift
+++ b/Powerup/SinkToSwimGameScene.swift
@@ -527,6 +527,7 @@ class SinkToSwimGameScene: SKScene {
     func gameOver(drowned: Bool) {
         isGameOver = true
         
+       
         // calling requestReviewIfAppropriate function for request to review Powerup
         AppStoreReviewManager.requestReviewIfAppropriate()
         

--- a/Utilities/UserDefaults+Key.swift
+++ b/Utilities/UserDefaults+Key.swift
@@ -1,0 +1,32 @@
+//
+//  UserDefaults+Key.swift
+//  Powerup
+//
+//  Created by Anubhav Singh on 14/02/20.
+//  Copyright © 2020 Systers. All rights reserved.
+//
+
+import Foundation
+
+extension UserDefaults {
+  enum Key: String {
+    case reviewWorthyActionCount
+    case lastReviewRequestAppVersion
+  }
+
+  func integer(forKey key: Key) -> Int {
+    return integer(forKey: key.rawValue)
+  }
+
+  func string(forKey key: Key) -> String? {
+    return string(forKey: key.rawValue)
+  }
+
+  func set(_ integer: Int, forKey key: Key) {
+    set(integer, forKey: key.rawValue)
+  }
+
+  func set(_ object: Any?, forKey key: Key) {
+    set(object, forKey: key.rawValue)
+  }
+}


### PR DESCRIPTION
### Description
Requesting ratings in Powerup-iOS apps. Starting with iOS 10.3, Apple introduced the new SKStoreReviewController class to standardize this interaction.

Choosing where and when to display this prompt is critical to your success using this API.
The moment the system shows the prompt to the user can have a great effect on the result when requesting app rating that's why I choose 'Sink To Swim' Game up to 'sink to swim' user experience full app to give a rating and when the transition to the game over scene then displays an in-app prompt that asks for a rating.

![PR3](https://user-images.githubusercontent.com/47811606/74273247-21458b80-4d36-11ea-9cad-477cc6c01485.png)


**Note: The Submit button will appear grayed out since you are in development mode. It will appear enabled for users using your app through the App Store.**

![pr3 1](https://user-images.githubusercontent.com/47811606/74273255-26a2d600-4d36-11ea-8223-397b210ded1b.png)


Fixes #334 

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
On Simulator


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

