### PR TITLE
Update link and access

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This will give you an exact copy of the current remote, make sure you don't have
 Links to the Documentation:<br />
 
 [2017](https://docs.google.com/document/d/1-45bBWAL8oh5o_1bc42BXGDKTHlGrQW0PCN9gFtlt6U/edit?usp=sharing)<br/>
-[2016](https://docs.google.com/document/d/1N_-zmmjPn6D1H6wTdF4z66mFGT3af_FWbfGvLKkeY1w/edit?usp=sharing)<br/>
+[2016](https://docs.google.com/document/d/1stQnZVDXp461qs2m6J9KHYwN-j58s-wEQsvNKjOQNm8/edit?usp=sharing)<br/>
 [2015](https://docs.google.com/document/d/1WkhcVrUs-B_vlCBknNPYqxqc7_7wVrBF2pV0bKu_EiQ/edit?usp=sharing)
 
 ## Contact


### PR DESCRIPTION
### Description
I changed the link of Documentation of 2016 and give access for view only and remove edit and comment option from document. 

Fixes #337 

### Type of Change:
**Delete irrelevant options.**

- Quality Assurance
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)

### How Has This Been Tested?
Tested with multiple google accounts.

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] Any dependent changes have been published in downstream modules
